### PR TITLE
Update homebrew install url

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -98,7 +98,7 @@ def install_homebrew
     puts "Homebrew installation is not script friendly right now"
     puts "Press [ENTER]"
     puts "======================================================"
-    run %{ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/master/install)"}
+    run %{ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"}
   end
 
   puts


### PR DESCRIPTION
While configuring .cf.files its unable to install homebrew as url for same has been changed. This PR fixes the homebrew install URL.